### PR TITLE
Add support for optional trailing slash in routes

### DIFF
--- a/lib/sinatra-authentication.rb
+++ b/lib/sinatra-authentication.rb
@@ -12,7 +12,7 @@ module Sinatra
       #loading the view from this path into a string and rendering it
       app.set :sinatra_authentication_view_path, File.expand_path('../views/', __FILE__)
 
-      app.get '/users' do
+      app.get '/users/?' do
         login_required
         redirect "/" unless current_user.admin?
 
@@ -24,7 +24,7 @@ module Sinatra
         end
       end
 
-      app.get '/users/:id' do
+      app.get '/users/:id/?' do
         login_required
 
         @user = User.get(:id => params[:id])
@@ -40,7 +40,7 @@ module Sinatra
         end
       end
 
-      app.get '/login' do
+      app.get '/login/?' do
         if session[:user]
           redirect '/'
         else
@@ -48,7 +48,7 @@ module Sinatra
         end
       end
 
-      app.post '/login' do
+      app.post '/login/?' do
         if user = User.authenticate(params[:email], params[:password])
           session[:user] = user.id
 
@@ -71,7 +71,7 @@ module Sinatra
         end
       end
 
-      app.get '/logout' do
+      app.get '/logout/?' do
         session[:user] = nil
         if Rack.const_defined?('Flash')
           flash[:notice] = "Logout successful."
@@ -79,7 +79,7 @@ module Sinatra
         redirect '/'
       end
 
-      app.get '/signup' do
+      app.get '/signup/?' do
         if session[:user]
           redirect '/'
         else
@@ -87,7 +87,7 @@ module Sinatra
         end
       end
 
-      app.post '/signup' do
+      app.post '/signup/?' do
         @user = User.set(params[:user])
         if @user.valid && @user.id
           session[:user] = @user.id
@@ -103,14 +103,14 @@ module Sinatra
         end
       end
 
-      app.get '/users/:id/edit' do
+      app.get '/users/:id/edit/?' do
         login_required
         redirect "/users" unless current_user.admin? || current_user.id.to_s == params[:id]
         @user = User.get(:id => params[:id])
         haml get_view_as_string("edit.haml"), :layout => use_layout?
       end
 
-      app.post '/users/:id/edit' do
+      app.post '/users/:id/edit/?' do
         login_required
         redirect "/users" unless current_user.admin? || current_user.id.to_s == params[:id]
 
@@ -134,7 +134,7 @@ module Sinatra
         end
       end
 
-      app.get '/users/:id/delete' do
+      app.get '/users/:id/delete/?' do
         login_required
         redirect "/users" unless current_user.admin? || current_user.id.to_s == params[:id]
 
@@ -152,7 +152,7 @@ module Sinatra
 
 
       if Sinatra.const_defined?('FacebookObject')
-        app.get '/connect' do
+        app.get '/connect/?' do
           if fb[:user]
             if current_user.class != GuestUser
               user = current_user


### PR DESCRIPTION
In case users want to have trailing slashes when accessing your routes.

You should probably make the redirects have trailing slashes by default, but of course thats up to you. http://sebastians-pamphlets.com/thou-must-not-steal-the-trailing-slash-from-my-urls/
@huboard:{"order":29.0}
