### PR TITLE
Stricter check with login_required.

### DIFF
--- a/lib/sinatra-authentication.rb
+++ b/lib/sinatra-authentication.rb
@@ -199,7 +199,8 @@ module Sinatra
 
     def login_required
       #not as efficient as checking the session. but this inits the fb_user if they are logged in
-      if current_user.class != GuestUser
+      user = current_user
+      if user && user.class != GuestUser
         return true
       else
         session[:return_to] = request.fullpath


### PR DESCRIPTION
A user deleted from a database will otherwise pass the login_required check, as it's "nil" and not a "GuestUser". (pending that the user already has their cookie and can pass the session check)
