### PR TITLE
Fixed ActiveRecord support and made flash messages work with sinatra-flash

### DIFF
--- a/lib/models/abstract_user.rb
+++ b/lib/models/abstract_user.rb
@@ -17,6 +17,9 @@ elsif Object.const_defined?("Sequel")
 elsif Object.const_defined?("Mongoid")
   require File.join(current_path, 'mongoid_user')
   require File.join(current_path, 'mongoid_adapter')
+elsif Object.const_defined?("ActiveRecord")
+  require File.join(current_path, 'ar_adapter')
+  require File.join(current_path, 'ar_user')
 end
 
 class User

--- a/lib/models/ar_adapter.rb
+++ b/lib/models/ar_adapter.rb
@@ -7,8 +7,8 @@ module ArAdapter
   module ClassMethods
     #pass all args to this
     def all
-      result = ArUser.all(:order => ["created_at DESC"])
-      result.collect {|instance| self.new instance}
+      result = ArUser.all.order("created_at DESC")
+      result.map{ |r| self.new r }
     end
 
     def get(hash)
@@ -51,7 +51,6 @@ module ArAdapter
 
     def update(attributes)
       @instance.update_attributes attributes
-      #self
     end
 
     def saved
@@ -59,7 +58,6 @@ module ArAdapter
     end
 
     def method_missing(meth, *args, &block)
-      #cool I just found out * on an array turns the array into a list of args for a function
       @instance.send(meth, *args, &block)
     end
   end

--- a/lib/models/ar_user.rb
+++ b/lib/models/ar_user.rb
@@ -1,4 +1,4 @@
-unless ActiveRecord::Base.connection.table_exists?("ar_users")
+unless (ActiveRecord::Base.connection.table_exists?("ar_users") rescue true)
   class CreateArUsers < ActiveRecord::Migration
     def self.up
       create_table :ar_users do |t|
@@ -23,11 +23,7 @@ unless ActiveRecord::Base.connection.table_exists?("ar_users")
   CreateArUsers.up
 end
 
-#require 'logger'
-#ActiveRecord::Base.logger = Logger.new(STDOUT)
-
 class ArUser < ActiveRecord::Base
-
   attr_accessor :password, :password_confirmation
 
   validates_format_of :email, :with => /(\A(\s*)\Z)|(\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\Z)/i

--- a/lib/views/edit.haml
+++ b/lib/views/edit.haml
@@ -1,8 +1,4 @@
 #sinatra_authentication
-  - if Rack.const_defined?('Flash') && flash[:notice]
-    #sinatra_authentication_flash= flash[:notice]
-  - if Rack.const_defined?('Flash') && flash[:error]
-    #sinatra_authentication_flash= flash[:error]
   %h1
     Edit
     - if @user.id == current_user.id

--- a/lib/views/login.haml
+++ b/lib/views/login.haml
@@ -1,8 +1,4 @@
 #sinatra_authentication
-  - if Rack.const_defined?('Flash') && flash[:notice]
-    #sinatra_authentication_flash= flash[:notice]
-  - if Rack.const_defined?('Flash') && flash[:error]
-    #sinatra_authentication_flash= flash[:error]
   %h1.page_title Login
   %form{:action => "/login", :method => "post"}
     .field

--- a/lib/views/signup.haml
+++ b/lib/views/signup.haml
@@ -1,8 +1,4 @@
 #sinatra_authentication
-  - if Rack.const_defined?('Flash') && flash[:notice]
-    #sinatra_authentication_flash= flash[:notice]
-  - if Rack.const_defined?('Flash') && flash[:error]
-    #sinatra_authentication_flash= flash[:error]
   %h1.page_title Sign Up
   %form{:action => "/signup", :method => "post"}
     .field

--- a/test/lib/ar_app.rb
+++ b/test/lib/ar_app.rb
@@ -14,7 +14,7 @@ use Rack::Session::Cookie, :secret => "heyhihello"
 use Rack::Flash
 
 set :environment, 'development'
-set :public, 'public'
+set :public_dir, 'public'
 set :views,  'views'
 
 get '/' do


### PR DESCRIPTION
Cleaned up a bunch of loose ends and got ActiveRecord support working fully.

1) Now works with sinatra-activerecord. All functionality works as expected. Tested all views.
2) Normalized ar files names.
3) Made sure rake db:create works by rescuing the setup if it fails (fails on non existent db).
4) Changed checks for session[:user] to use logged_in? instead.
5) Changed flash code to detect the flash object, enabling the use of sinatra-flash
6) Added simple user cache for current_user. That way multiple accesses don't hit the db.
7) Changed edit page to 'Edit Profile', and capitalized some links. Also added -'s between so they look a bit nicer.
8) Removed display of notifications in the default views. They are in most people's global layout, so they shouldn't be in the base. 
9) Fixed ArApp to use public_dir instead of public.
